### PR TITLE
Add support for optional 'options' dictionary

### DIFF
--- a/examples/python/blend_images.py
+++ b/examples/python/blend_images.py
@@ -11,8 +11,15 @@ pconvert.blend_images(
     os.path.abspath("result.png")
 )
 
+# this example supplies an optional parameter called `options` which pconvert-rust uses
+# despite not being used by this pconvert version, it is backwards compatible
 pconvert.blend_images(
     os.path.abspath("result.png"),
     os.path.abspath("../../assets/demo/front.png"),
-    os.path.abspath("result.png")
+    os.path.abspath("result.png"),
+    options = {
+        "num_threads": 20,
+        "compression": "best",
+        "filter": "nofilter"
+    }
 )

--- a/examples/python/blend_multiple.py
+++ b/examples/python/blend_multiple.py
@@ -11,9 +11,12 @@ pconvert.blend_multiple(
         os.path.abspath("../../assets/demo/back.png"),
         os.path.abspath("../../assets/demo/front.png")
     ),
-    os.path.abspath("result.basic.png")
+    os.path.abspath("result.basic.png"),
+    is_inline = True
 )
 
+# this example supplies an optional parameter called `options` which pconvert-rust uses
+# despite not being used by this pconvert version, it is backwards compatible
 pconvert.blend_multiple(
     (
         os.path.abspath("../../assets/demo/sole.png"),
@@ -22,5 +25,9 @@ pconvert.blend_multiple(
     ),
     os.path.abspath("result.destination_over.png"),
     algorithm = "destination_over",
-    is_inline = True
+    options = {
+        "num_threads": 20,
+        "compression": "best",
+        "filter": "nofilter"
+    }
 )

--- a/src/pconvert/extension.c
+++ b/src/pconvert/extension.c
@@ -105,6 +105,7 @@ PyObject *extension_blend_images(PyObject *self, PyObject *args, PyObject *kwarg
     char demultiply, source_over, destination_over;
     char *bottom_path, *top_path, *target_path, *algorithm;
     PyObject *is_inline, *params_py;
+    PyDictObject *options;
     struct pcv_image bottom, top;
     param values[32];
     params params = { 0, values };
@@ -114,6 +115,7 @@ PyObject *extension_blend_images(PyObject *self, PyObject *args, PyObject *kwarg
         "target_path",
         "algorithm",
         "is_inline",
+        "options",
         "params",
         NULL
     };
@@ -123,6 +125,7 @@ PyObject *extension_blend_images(PyObject *self, PyObject *args, PyObject *kwarg
     target_path = NULL;
     algorithm = NULL;
     is_inline = NULL;
+    options = NULL;
     params_py = NULL;
 
     set_last_error(NULL);
@@ -130,13 +133,14 @@ PyObject *extension_blend_images(PyObject *self, PyObject *args, PyObject *kwarg
     if(PyArg_ParseTupleAndKeywords(
         args,
         kwargs,
-        "sss|sO",
+        "sss|sOOO",
         kwlist,
         &bottom_path,
         &top_path,
         &target_path,
         &algorithm,
-        &is_inline
+        &is_inline,
+        &options
     ) == 0) { return NULL; }
 
     algorithm = algorithm == NULL ? "multiplicative" : algorithm;
@@ -190,6 +194,7 @@ PyObject *extension_blend_multiple(PyObject *self, PyObject *args, PyObject *kwa
     struct pcv_image bottom, top;
     PyObject *paths, *iterator, *iteratorAlgorithms, *element, *first, *second,
         *is_inline, *algorithms, *algorithm_o, *algorithm_so, *params_py;
+    PyDictObject *options;
     Py_ssize_t size, algorithms_size;
     param values[32];
     params params = { 0, values };
@@ -199,6 +204,7 @@ PyObject *extension_blend_multiple(PyObject *self, PyObject *args, PyObject *kwa
         "algorithm",
         "algorithms",
         "is_inline",
+        "options",
         "params",
         NULL
     };
@@ -212,6 +218,7 @@ PyObject *extension_blend_multiple(PyObject *self, PyObject *args, PyObject *kwa
     algorithm = NULL;
     algorithms = NULL;
     is_inline = NULL;
+    options = NULL;
     params_py = NULL;
 
     set_last_error(NULL);
@@ -219,13 +226,14 @@ PyObject *extension_blend_multiple(PyObject *self, PyObject *args, PyObject *kwa
     if(PyArg_ParseTupleAndKeywords(
         args,
         kwargs,
-        "Os|sOOO",
+        "Os|sOOOO",
         kwlist,
         &paths,
         &target_path,
         &algorithm,
         &algorithms,
         &is_inline,
+        &options,
         &params_py
     ) == 0) { return NULL; }
 


### PR DESCRIPTION
Add support for optional `options` dictionary to make original pconvert compatible with pconvert-rust for a seemingless integration of any pconvert version.